### PR TITLE
feat: :zap: add training time and auroc radar graph

### DIFF
--- a/tools/generate_training_time_netzdiagram.py
+++ b/tools/generate_training_time_netzdiagram.py
@@ -1,0 +1,193 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import matplotlib.cm as cm
+from matplotlib.ticker import FuncFormatter
+from matplotlib.lines import Line2D
+
+# Custom scale function for compressing the 0-60 range, expanding the 60-100 range
+def custom_scale(y):
+    return np.where(y <= 60, y * 0.3 / 60, 0.3 + (y - 60) * 0.7 / 40)
+
+# 反向的自定义刻度函数 - 用于显示刻度标签
+def inverse_custom_scale(y):
+    return np.where(y <= 0.3, y * 60 / 0.3, 60 + (y - 0.3) * 40 / 0.7)
+
+# 获取脚本目录
+script_dir = os.path.dirname(os.path.abspath(__file__))
+# 日志目录
+logs_dir = os.path.join(script_dir, '..', 'logs', 'training_time')
+# 输出路径
+output_dir = os.path.join(script_dir, '..', 'output')
+# 如果输出目录不存在，则创建
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+
+# 定义数据集信息（样本数和类别数）
+dataset_info = {
+    'visa': {'samples': 10281, 'categories': 12},
+    'mvtec': {'samples': 5354, 'categories': 15},
+    'mvtec3d': {'samples': 5312, 'categories': 10},
+    'btech': {'samples': 2830, 'categories': 3},
+    'kolektor': {'samples': 399, 'categories': 1}
+}
+
+# 按样本数量降序排列数据集
+sorted_datasets = sorted(dataset_info.keys(), key=lambda x: dataset_info[x]['samples'], reverse=True)
+
+# 数据集CSV文件路径
+file_paths = {
+    dataset: os.path.join(logs_dir, f"{dataset}.csv")
+    for dataset in dataset_info.keys()
+}
+
+# 打印文件路径用于调试
+for name, path in file_paths.items():
+    print(f"Looking for {name} at: {os.path.abspath(path)}")
+
+# 读取CSV文件
+dfs = {name: pd.read_csv(path) for name, path in file_paths.items()}
+
+# 获取所有唯一的模型名称
+all_models = []
+for df in dfs.values():
+    all_models.extend(df['model'].tolist())
+all_models = sorted(list(set(all_models)))
+
+# 创建用于绘图的数据结构
+auroc_values = {}  # 存储每个模型在每个数据集上的AUROC值
+
+# 处理数据
+for model in all_models:
+    auroc_values[model] = []
+    
+    for dataset in sorted_datasets:
+        df = dfs[dataset]
+        if model in df['model'].values:
+            # 获取该模型在当前数据集的AUROC值
+            model_row = df[df['model'] == model].iloc[0]
+            auroc = float(model_row['image auroc value'])
+            
+            auroc_values[model].append(auroc)
+        else:
+            # 如果该模型在当前数据集中不存在，填充None
+            auroc_values[model].append(None)
+
+# 计算每个模型的平均AUROC值
+model_avg_auroc = {}
+for model in all_models:
+    valid_aurocs = [a for a in auroc_values[model] if a is not None]
+    if valid_aurocs:
+        model_avg_auroc[model] = sum(valid_aurocs) / len(valid_aurocs)
+    else:
+        model_avg_auroc[model] = 0
+
+# 按平均AUROC值排序所有模型
+sorted_models = sorted(model_avg_auroc.keys(), key=lambda m: model_avg_auroc[m], reverse=True)
+print(f"Found {len(sorted_models)} models: {sorted_models}")
+
+# 创建一个较大的图表以容纳所有15个模型
+fig = plt.figure(figsize=(18, 16))
+ax = fig.add_subplot(111, polar=True)
+
+# 确定角度
+angles = np.linspace(0, 2*np.pi, len(sorted_datasets), endpoint=False).tolist()
+# 闭合图形
+angles += angles[:1]
+
+# 设置雷达图的方向，从上方开始
+ax.set_theta_offset(np.pi / 2)
+ax.set_theta_direction(-1)
+
+# 设置每个点的标签
+ax.set_xticks(angles[:-1])
+ax.set_xticklabels([dataset.upper() for dataset in sorted_datasets], fontsize=14, fontweight='bold')
+
+# 应用自定义刻度
+scaled_rgrids = [custom_scale(val) for val in [0, 20, 40, 60, 70, 80, 90, 95, 100]]
+label_rgrids = [0, 20, 40, 60, 70, 80, 90, 95, 100]
+
+# 设置y轴范围，应用自定义刻度
+ax.set_ylim(0, 1)  # 缩放后的范围是0-1
+ax.set_rgrids(scaled_rgrids, labels=[f"{val}" for val in label_rgrids], fontsize=12)
+
+# 绘制60的特殊环线，用虚线标记
+sixty_circle = plt.Circle((0, 0), custom_scale(60), transform=ax.transData._b, 
+                        fill=False, edgecolor='gray', linestyle='--', linewidth=1)
+ax.add_artist(sixty_circle)
+
+# 标记60分隔线
+plt.text(0, custom_scale(60) + 0.02, "60", transform=ax.transData._b, 
+        horizontalalignment='center', verticalalignment='bottom', 
+        fontsize=12, color='gray')
+
+# 使用HSV颜色空间创建一系列清晰可区分的颜色
+hues = np.linspace(0, 1, len(sorted_models), endpoint=False)
+colors = [plt.cm.hsv(h) for h in hues]
+
+# 定义线型和标记符
+line_styles = ['-', '--', '-.', ':']
+markers = ['o', 's', '^', 'D', 'v', 'p', '*', 'h', '8', '+', 'x', 'd', '|', '_', '.']
+
+# 存储每个模型的图形元素，用于创建图例
+legend_elements = []
+
+# 绘制每个模型的雷达图
+for i, model in enumerate(sorted_models):
+    values = [v if v is not None else 0 for v in auroc_values[model]]
+    # 应用自定义刻度
+    scaled_values = [custom_scale(v) for v in values]
+    # 闭合数据
+    scaled_values += scaled_values[:1]
+    
+    # 确定线宽和线型
+    line_width = 2.5
+    line_style = line_styles[i % len(line_styles)]
+    marker = markers[i % len(markers)]
+    color = colors[i]
+    
+    # 绘制线条
+    line = ax.plot(angles, scaled_values, 
+            linewidth=line_width, 
+            color=color, 
+            linestyle=line_style, 
+            marker=marker, 
+            markersize=8,
+            label=model)[0]
+    
+    # 为所有模型填充区域，使用相同的透明度
+    ax.fill(angles, scaled_values, color=color, alpha=0.15)
+    
+    # 创建图例元素
+    legend_elements.append(
+        Line2D([0], [0], color=color, lw=line_width, linestyle=line_style, 
+               marker=marker, markersize=8, 
+               label=f"{model} (avg: {model_avg_auroc[model]:.1f})")
+    )
+
+# 创建单一图例，包含所有模型
+ax.legend(handles=legend_elements, 
+          loc='center left', 
+          bbox_to_anchor=(1.05, 0.5),
+          fontsize=13, 
+          title="Models with Average AUROC", 
+          title_fontsize=15)
+
+# 添加标题
+plt.title('AUROC Values for All Models Across Different Datasets', size=18, y=1.05)
+
+# 紧凑布局
+plt.tight_layout()
+
+# 保存图表
+output_path = os.path.join(output_dir, 'auroc_radar_chart_all_models.png')
+plt.savefig(output_path, format='png', dpi=300, bbox_inches='tight')
+print(f"All models radar chart saved to: {os.path.abspath(output_path)}")
+
+# 保存为SVG
+svg_path = os.path.join(output_dir, 'auroc_radar_chart_all_models.svg')
+plt.savefig(svg_path, format='svg', bbox_inches='tight')
+print(f"All models radar chart also saved as SVG to: {os.path.abspath(svg_path)}")
+
+plt.close()

--- a/tools/generate_training_time_netzdiagram.py
+++ b/tools/generate_training_time_netzdiagram.py
@@ -10,21 +10,21 @@ from matplotlib.lines import Line2D
 def custom_scale(y):
     return np.where(y <= 60, y * 0.3 / 60, 0.3 + (y - 60) * 0.7 / 40)
 
-# 反向的自定义刻度函数 - 用于显示刻度标签
+# Inverse custom scale function - used for displaying scale labels
 def inverse_custom_scale(y):
     return np.where(y <= 0.3, y * 60 / 0.3, 60 + (y - 0.3) * 40 / 0.7)
 
-# 获取脚本目录
+# Get script directory
 script_dir = os.path.dirname(os.path.abspath(__file__))
-# 日志目录
+# Logs directory
 logs_dir = os.path.join(script_dir, '..', 'logs', 'training_time')
-# 输出路径
+# Output path
 output_dir = os.path.join(script_dir, '..', 'output')
-# 如果输出目录不存在，则创建
+# Create output directory if it doesn't exist
 if not os.path.exists(output_dir):
     os.makedirs(output_dir)
 
-# 定义数据集信息（样本数和类别数）
+# Define dataset information (number of samples and number of categories)
 dataset_info = {
     'visa': {'samples': 10281, 'categories': 12},
     'mvtec': {'samples': 5354, 'categories': 15},
@@ -33,48 +33,48 @@ dataset_info = {
     'kolektor': {'samples': 399, 'categories': 1}
 }
 
-# 按样本数量降序排列数据集
+# Sort datasets by sample count in descending order
 sorted_datasets = sorted(dataset_info.keys(), key=lambda x: dataset_info[x]['samples'], reverse=True)
 
-# 数据集CSV文件路径
+# Dataset CSV file paths
 file_paths = {
     dataset: os.path.join(logs_dir, f"{dataset}.csv")
     for dataset in dataset_info.keys()
 }
 
-# 打印文件路径用于调试
+# Print file paths for debugging
 for name, path in file_paths.items():
     print(f"Looking for {name} at: {os.path.abspath(path)}")
 
-# 读取CSV文件
+# Read CSV files
 dfs = {name: pd.read_csv(path) for name, path in file_paths.items()}
 
-# 获取所有唯一的模型名称
+# Get all unique model names
 all_models = []
 for df in dfs.values():
     all_models.extend(df['model'].tolist())
 all_models = sorted(list(set(all_models)))
 
-# 创建用于绘图的数据结构
-auroc_values = {}  # 存储每个模型在每个数据集上的AUROC值
+# Create data structure for plotting
+auroc_values = {}  # Store AUROC values for each model on each dataset
 
-# 处理数据
+# Process data
 for model in all_models:
     auroc_values[model] = []
     
     for dataset in sorted_datasets:
         df = dfs[dataset]
         if model in df['model'].values:
-            # 获取该模型在当前数据集的AUROC值
+            # Get AUROC value for the model on the current dataset
             model_row = df[df['model'] == model].iloc[0]
             auroc = float(model_row['image auroc value'])
             
             auroc_values[model].append(auroc)
         else:
-            # 如果该模型在当前数据集中不存在，填充None
+            # If the model does not exist in the current dataset, fill with None
             auroc_values[model].append(None)
 
-# 计算每个模型的平均AUROC值
+# Calculate average AUROC for each model
 model_avg_auroc = {}
 for model in all_models:
     valid_aurocs = [a for a in auroc_values[model] if a is not None]
@@ -83,71 +83,71 @@ for model in all_models:
     else:
         model_avg_auroc[model] = 0
 
-# 按平均AUROC值排序所有模型
+# Sort all models by average AUROC
 sorted_models = sorted(model_avg_auroc.keys(), key=lambda m: model_avg_auroc[m], reverse=True)
 print(f"Found {len(sorted_models)} models: {sorted_models}")
 
-# 创建一个较大的图表以容纳所有15个模型
+# Create a larger chart to accommodate all 15 models
 fig = plt.figure(figsize=(18, 16))
 ax = fig.add_subplot(111, polar=True)
 
-# 确定角度
+# Determine angles
 angles = np.linspace(0, 2*np.pi, len(sorted_datasets), endpoint=False).tolist()
-# 闭合图形
+# Close the figure
 angles += angles[:1]
 
-# 设置雷达图的方向，从上方开始
+# Set radar chart direction, starting from above
 ax.set_theta_offset(np.pi / 2)
 ax.set_theta_direction(-1)
 
-# 设置每个点的标签
+# Set labels for each point
 ax.set_xticks(angles[:-1])
 ax.set_xticklabels([dataset.upper() for dataset in sorted_datasets], fontsize=14, fontweight='bold')
 
-# 应用自定义刻度
+# Apply custom scale
 scaled_rgrids = [custom_scale(val) for val in [0, 20, 40, 60, 70, 80, 90, 95, 100]]
 label_rgrids = [0, 20, 40, 60, 70, 80, 90, 95, 100]
 
-# 设置y轴范围，应用自定义刻度
-ax.set_ylim(0, 1)  # 缩放后的范围是0-1
+# Set y-axis range, apply custom scale
+ax.set_ylim(0, 1)  # Scaled range is 0-1
 ax.set_rgrids(scaled_rgrids, labels=[f"{val}" for val in label_rgrids], fontsize=12)
 
-# 绘制60的特殊环线，用虚线标记
+# Draw special 60 circle, marked with dashed line
 sixty_circle = plt.Circle((0, 0), custom_scale(60), transform=ax.transData._b, 
                         fill=False, edgecolor='gray', linestyle='--', linewidth=1)
 ax.add_artist(sixty_circle)
 
-# 标记60分隔线
+# Mark 60 separator
 plt.text(0, custom_scale(60) + 0.02, "60", transform=ax.transData._b, 
         horizontalalignment='center', verticalalignment='bottom', 
         fontsize=12, color='gray')
 
-# 使用HSV颜色空间创建一系列清晰可区分的颜色
+# Use HSV color space to create a series of clear distinguishable colors
 hues = np.linspace(0, 1, len(sorted_models), endpoint=False)
 colors = [plt.cm.hsv(h) for h in hues]
 
-# 定义线型和标记符
+# Define line type and marker
 line_styles = ['-', '--', '-.', ':']
 markers = ['o', 's', '^', 'D', 'v', 'p', '*', 'h', '8', '+', 'x', 'd', '|', '_', '.']
 
-# 存储每个模型的图形元素，用于创建图例
+# Store graphic elements for each model, used to create legend
 legend_elements = []
 
-# 绘制每个模型的雷达图
+# Draw radar chart for each model
 for i, model in enumerate(sorted_models):
     values = [v if v is not None else 0 for v in auroc_values[model]]
-    # 应用自定义刻度
+    # Apply custom scale
     scaled_values = [custom_scale(v) for v in values]
-    # 闭合数据
+    # Close data
     scaled_values += scaled_values[:1]
     
-    # 确定线宽和线型
+    # Determine line width and line type
     line_width = 2.5
     line_style = line_styles[i % len(line_styles)]
     marker = markers[i % len(markers)]
     color = colors[i]
     
-    # 绘制线条
+    # Draw line
     line = ax.plot(angles, scaled_values, 
             linewidth=line_width, 
             color=color, 
@@ -156,17 +156,17 @@ for i, model in enumerate(sorted_models):
             markersize=8,
             label=model)[0]
     
-    # 为所有模型填充区域，使用相同的透明度
+    # Fill area for all models, using same transparency
     ax.fill(angles, scaled_values, color=color, alpha=0.15)
     
-    # 创建图例元素
+    # Create legend element
     legend_elements.append(
         Line2D([0], [0], color=color, lw=line_width, linestyle=line_style, 
                marker=marker, markersize=8, 
                label=f"{model} (avg: {model_avg_auroc[model]:.1f})")
     )
 
-# 创建单一图例，包含所有模型
+# Create single legend, containing all models
 ax.legend(handles=legend_elements, 
           loc='center left', 
           bbox_to_anchor=(1.05, 0.5),
@@ -174,18 +174,18 @@ ax.legend(handles=legend_elements,
           title="Models with Average AUROC", 
           title_fontsize=15)
 
-# 添加标题
+# Add title
 plt.title('AUROC Values for All Models Across Different Datasets', size=18, y=1.05)
 
-# 紧凑布局
+# Compact layout
 plt.tight_layout()
 
-# 保存图表
+# Save chart
 output_path = os.path.join(output_dir, 'auroc_radar_chart_all_models.png')
 plt.savefig(output_path, format='png', dpi=300, bbox_inches='tight')
 print(f"All models radar chart saved to: {os.path.abspath(output_path)}")
 
-# 保存为SVG
+# Save as SVG
 svg_path = os.path.join(output_dir, 'auroc_radar_chart_all_models.svg')
 plt.savefig(svg_path, format='svg', bbox_inches='tight')
 print(f"All models radar chart also saved as SVG to: {os.path.abspath(svg_path)}")

--- a/tools/generate_training_time_plot.py
+++ b/tools/generate_training_time_plot.py
@@ -11,13 +11,13 @@ def custom_scale(y):
 script_dir = os.path.dirname(os.path.abspath(__file__))
 # Navigate to the logs directory
 logs_dir = os.path.join(script_dir, '..', 'logs', 'training_time')
-# 输出路径
+# Output path
 output_dir = os.path.join(script_dir, '..', 'output')
-# 如果输出目录不存在，则创建
+# Create output directory if it doesn't exist
 if not os.path.exists(output_dir):
     os.makedirs(output_dir)
 
-# 定义数据集信息（样本数和类别数）
+# Define dataset information (number of samples and categories)
 dataset_info = {
     'visa': {'samples': 10281, 'categories': 12},
     'mvtec': {'samples': 5354, 'categories': 15},
@@ -26,10 +26,10 @@ dataset_info = {
     'kolektor': {'samples': 399, 'categories': 1}
 }
 
-# 按样本数量降序排列数据集
+# Sort datasets by sample count in descending order
 sorted_datasets = sorted(dataset_info.keys(), key=lambda x: dataset_info[x]['samples'], reverse=True)
 
-# 数据集CSV文件路径
+# Dataset CSV file paths
 file_paths = {
     dataset: os.path.join(logs_dir, f"{dataset}.csv")
     for dataset in dataset_info.keys()
@@ -42,44 +42,44 @@ for name, path in file_paths.items():
 # Read the CSV files
 dfs = {name: pd.read_csv(path) for name, path in file_paths.items()}
 
-# 获取所有唯一的模型名称
+# Get all unique model names
 all_models = []
 for df in dfs.values():
     all_models.extend(df['model'].tolist())
 all_models = sorted(list(set(all_models)))
 
-# 创建用于绘图的数据结构
-training_times = {}  # 存储每个模型在每个数据集上的训练时间
+# Create data structure for plotting
+training_times = {}  # Store training time for each model on each dataset
 
-# 处理数据
+# Process data
 for model in all_models:
     training_times[model] = []
     
     for dataset in sorted_datasets:
         df = dfs[dataset]
         if model in df['model'].values:
-            # 获取该模型在当前数据集的训练时间
+            # Get training time for the model on the current dataset
             model_row = df[df['model'] == model].iloc[0]
             training_time = int(model_row['training time'].rstrip('s'))
             
             training_times[model].append(training_time)
         else:
-            # 如果该模型在当前数据集中不存在，填充None
+            # If the model does not exist in the current dataset, fill with None
             training_times[model].append(None)
 
 # Plotting
 fig, ax = plt.subplots(figsize=(14, 10))
 
-# 每个模型对应一种颜色
+# Each model corresponds to a different color
 colors = plt.cm.tab20(np.linspace(0, 1, len(all_models)))
 markers = ['o', 's', '^', 'D', 'v', 'p', '*', 'h', '8', '+', 'x']
 
-# 创建x轴位置
+# Create x-axis positions
 x = np.arange(len(sorted_datasets))
 
-# 为每个模型绘制折线图
+# Draw line plots for each model
 for i, model in enumerate(all_models):
-    # 过滤掉None值
+    # Filter out None values
     valid_indices = [j for j, t in enumerate(training_times[model]) if t is not None]
     valid_x = [x[j] for j in valid_indices]
     valid_times = [training_times[model][j] for j in valid_indices]
@@ -87,30 +87,30 @@ for i, model in enumerate(all_models):
     if not valid_times:
         continue
     
-    # 绘制折线
+    # Draw line
     ax.plot(valid_x, valid_times, marker=markers[i % len(markers)], 
              markersize=10, color=colors[i], linewidth=2, label=model)
 
-# 设置x轴标签为数据集名称和样本数量
+# Set x-axis label to dataset name and sample count
 ax.set_xticks(x)
 x_labels = [f"{dataset.upper()}\n({dataset_info[dataset]['samples']} samples)" for dataset in sorted_datasets]
 ax.set_xticklabels(x_labels)
 
-# 设置y轴为对数刻度，更好地显示不同数量级的训练时间
+# Set y-axis to logarithmic scale for better display of different order of training time
 ax.set_yscale('log')
 
-# 添加标题和标签
+# Add title and labels
 ax.set_title('Training Time vs Datasets for Different Models', fontsize=16)
 ax.set_xlabel('Datasets (Sorted by Sample Size)', fontsize=14)
 ax.set_ylabel('Training Time (seconds, log scale)', fontsize=14)
 
-# 添加图例，放在图外部右侧
+# Add legend, placed outside the figure on the right
 ax.legend(title='Models', bbox_to_anchor=(1.05, 1), loc='upper left', fontsize=12)
 
-# 添加网格线
+# Add grid lines
 ax.grid(True, linestyle='--', alpha=0.7)
 
-# 紧凑布局
+# Compact layout
 plt.tight_layout()
 
 # Save plot as a PNG
@@ -118,10 +118,10 @@ output_path = os.path.join(output_dir, 'training_time_by_dataset.png')
 plt.savefig(output_path, format='png', dpi=300, bbox_inches='tight')
 print(f"Plot saved to: {os.path.abspath(output_path)}")
 
-# 保存为SVG
+# Save as SVG
 svg_path = os.path.join(output_dir, 'training_time_by_dataset.svg')
 plt.savefig(svg_path, format='svg', bbox_inches='tight')
 print(f"Plot also saved as SVG to: {os.path.abspath(svg_path)}")
 
-# 不显示图形，避免阻塞
+# Do not display the figure to avoid blocking
 # plt.show()

--- a/tools/generate_training_time_plot.py
+++ b/tools/generate_training_time_plot.py
@@ -1,76 +1,127 @@
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np
+import os
 
-# Custom scale function
+# Custom scale function for training time
 def custom_scale(y):
     return np.where(y <= 10000, y / 10000 * 0.5, 0.5 + (y - 10000) / 340000 * 0.5)
 
-# Function to check overlap between annotations based on training time
-def is_overlapping(training_time, existing_annotations, threshold=15000):
-    for ex in existing_annotations:
-        if abs(training_time - ex) < threshold:
-            return True
-    return False
+# Get the script directory
+script_dir = os.path.dirname(os.path.abspath(__file__))
+# Navigate to the logs directory
+logs_dir = os.path.join(script_dir, '..', 'logs', 'training_time')
+# 输出路径
+output_dir = os.path.join(script_dir, '..', 'output')
+# 如果输出目录不存在，则创建
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
 
-# Data for CSV files
-file_paths = {
-    'btech': '../logs/training_time/btech.csv',
-    'kolektor': '../logs/training_time/kolektor.csv',
-    'mvtec': '../logs/training_time/mvtec.csv',
-    'mvtec3d': '../logs/training_time/mvtec3d.csv',
-    'visa': '../logs/training_time/visa.csv'
+# 定义数据集信息（样本数和类别数）
+dataset_info = {
+    'visa': {'samples': 10281, 'categories': 12},
+    'mvtec': {'samples': 5354, 'categories': 15},
+    'mvtec3d': {'samples': 5312, 'categories': 10},
+    'btech': {'samples': 2830, 'categories': 3},
+    'kolektor': {'samples': 399, 'categories': 1}
 }
+
+# 按样本数量降序排列数据集
+sorted_datasets = sorted(dataset_info.keys(), key=lambda x: dataset_info[x]['samples'], reverse=True)
+
+# 数据集CSV文件路径
+file_paths = {
+    dataset: os.path.join(logs_dir, f"{dataset}.csv")
+    for dataset in dataset_info.keys()
+}
+
+# Print the absolute paths for debugging
+for name, path in file_paths.items():
+    print(f"Looking for {name} at: {os.path.abspath(path)}")
 
 # Read the CSV files
 dfs = {name: pd.read_csv(path) for name, path in file_paths.items()}
 
+# 获取所有唯一的模型名称
+all_models = []
+for df in dfs.values():
+    all_models.extend(df['model'].tolist())
+all_models = sorted(list(set(all_models)))
+
+# 创建用于绘图的数据结构
+training_times = {}  # 存储每个模型在每个数据集上的训练时间
+
+# 处理数据
+for model in all_models:
+    training_times[model] = []
+    
+    for dataset in sorted_datasets:
+        df = dfs[dataset]
+        if model in df['model'].values:
+            # 获取该模型在当前数据集的训练时间
+            model_row = df[df['model'] == model].iloc[0]
+            training_time = int(model_row['training time'].rstrip('s'))
+            
+            training_times[model].append(training_time)
+        else:
+            # 如果该模型在当前数据集中不存在，填充None
+            training_times[model].append(None)
+
 # Plotting
-plt.figure(figsize=(12, 8))
+fig, ax = plt.subplots(figsize=(14, 10))
 
-for label, df in dfs.items():
-    # Strip 's' from training time and convert to int
-    df['training time'] = df['training time'].str.rstrip('s').astype(int)
+# 每个模型对应一种颜色
+colors = plt.cm.tab20(np.linspace(0, 1, len(all_models)))
+markers = ['o', 's', '^', 'D', 'v', 'p', '*', 'h', '8', '+', 'x']
 
-    # Apply custom scaling to y values
-    scaled_training_time = custom_scale(df['training time'])
-    plt.plot(df['model'], scaled_training_time, marker='o', label=label)
+# 创建x轴位置
+x = np.arange(len(sorted_datasets))
 
-    # Annotating each point with its corresponding image auroc value
-    existing_annotations = []
-    for i, (txt, model, training_time, scaled_time) in enumerate(zip(df['image auroc value'], df['model'], df['training time'], scaled_training_time)):
-        offset_x = -20 if i % 2 == 0 else 20
-        offset_y = 10 if i % 2 == 0 else -10
+# 为每个模型绘制折线图
+for i, model in enumerate(all_models):
+    # 过滤掉None值
+    valid_indices = [j for j, t in enumerate(training_times[model]) if t is not None]
+    valid_x = [x[j] for j in valid_indices]
+    valid_times = [training_times[model][j] for j in valid_indices]
+    
+    if not valid_times:
+        continue
+    
+    # 绘制折线
+    ax.plot(valid_x, valid_times, marker=markers[i % len(markers)], 
+             markersize=10, color=colors[i], linewidth=2, label=model)
 
-        # Print debug information
-        print(f"Checking model: {model}, training time: {training_time}, scaled time: {scaled_time:.2f}")
+# 设置x轴标签为数据集名称和样本数量
+ax.set_xticks(x)
+x_labels = [f"{dataset.upper()}\n({dataset_info[dataset]['samples']} samples)" for dataset in sorted_datasets]
+ax.set_xticklabels(x_labels)
 
-        # Check for overlap with existing annotations based on training time
-        if is_overlapping(training_time, existing_annotations):
-            print(f"Skipping annotation for {model} with training time {training_time} (scaled: {scaled_time:.2f}) due to overlap")
-            continue
+# 设置y轴为对数刻度，更好地显示不同数量级的训练时间
+ax.set_yscale('log')
 
-        # Add annotation
-        plt.annotate(f'{txt}', (df['model'][i], scaled_time),
-                     textcoords="offset points", xytext=(offset_x, offset_y), ha='center', fontsize=8)
+# 添加标题和标签
+ax.set_title('Training Time vs Datasets for Different Models', fontsize=16)
+ax.set_xlabel('Datasets (Sorted by Sample Size)', fontsize=14)
+ax.set_ylabel('Training Time (seconds, log scale)', fontsize=14)
 
-        # Record this annotation to check for future overlaps
-        existing_annotations.append(training_time)
+# 添加图例，放在图外部右侧
+ax.legend(title='Models', bbox_to_anchor=(1.05, 1), loc='upper left', fontsize=12)
 
-# Adjusting y-axis labels
-y_ticks = [0, 5000, 10000, 50000, 100000, 200000, 300000, 350000]
-plt.yticks(custom_scale(np.array(y_ticks)), y_ticks)
+# 添加网格线
+ax.grid(True, linestyle='--', alpha=0.7)
 
-# Adding titles and labels
-plt.title('Training Time and Image AUROC Value for Different Models')
-plt.xlabel('Model Name')
-plt.ylabel('Training Time (s)')
-plt.xticks(rotation=90)
-plt.legend(title='Datasets')
+# 紧凑布局
 plt.tight_layout()
 
-# Save plot as a PDF
-# plt.savefig('training_time_vs_image_auroc.pdf', format='pdf')
+# Save plot as a PNG
+output_path = os.path.join(output_dir, 'training_time_by_dataset.png')
+plt.savefig(output_path, format='png', dpi=300, bbox_inches='tight')
+print(f"Plot saved to: {os.path.abspath(output_path)}")
 
-# Show plot
-plt.show()
+# 保存为SVG
+svg_path = os.path.join(output_dir, 'training_time_by_dataset.svg')
+plt.savefig(svg_path, format='svg', bbox_inches='tight')
+print(f"Plot also saved as SVG to: {os.path.abspath(svg_path)}")
+
+# 不显示图形，避免阻塞
+# plt.show()


### PR DESCRIPTION
Remove old training time graph logic, regarding Max's review: 

"Already mentioned: Why does it make sense to connect the points? Would it not make more sense to pack the datasets on the x-axis and sort them by size to get a statement about the performance of the algorithms?" and "Those are really hard to read and it makes no sense to just put them on the x-axis, then use a network graph" 

Now the training time graph is split into training time and image auroc values for better visualisation.